### PR TITLE
Удалять мягкие переносы (soft hyphen)

### DIFF
--- a/js/tran.coffee
+++ b/js/tran.coffee
@@ -18,10 +18,17 @@ window.tran =
   click: (data) ->
     if typeof data.silent == undefined || data.silent == null
       data.silent = true # true by default
+    selectionText = tran.removeHyphenation data.selectionText
     tran.search
-        value: data.selectionText
+        value: selectionText
         success: tran.successtHandler
         silent: data.silent  # if translation failed do not show dialog
+
+  ###
+    Discard soft hyphen character (U+00AD, &shy;) from the input
+  ###
+  removeHyphenation: (text) ->
+    text.replace /\xad/g, ''
 
   ###
     Initiate translation search


### PR DESCRIPTION
[Иногда](http://www.nomachetejuggling.com/2008/12/11/my-least-favorite-interview-question/) в тексте встречаются символы мягких переносов ([soft hyphen](http://graphemica.com/00AD)), из-за которых адрес запроса выглядит так:

```
http://www.multitran.ru/c/m.exe?l1=2&l2=1&s=palat%C2%ADable
```

Проверить можно по ссылке в начале (например, в слове “interview” в первой же строке есть два переноса) или здесь: http://jsbin.com/sivuk/1
