### PR TITLE
Явно указывать display:inline для изображений

### DIFF
--- a/less/dialog.less
+++ b/less/dialog.less
@@ -61,6 +61,7 @@
     }
 
     .mtt_img {
+      display: inline;
       margin: 0;
       padding: 0;
     }


### PR DESCRIPTION
На [некоторых сайтах](http://www.newyorker.com/) транскрипция отображается некорректно из-за глобального `img { display: block }`.
![tran-yorker](https://cloud.githubusercontent.com/assets/4472489/3733384/54440d1a-1707-11e4-8ec2-8e831a7e21b6.png)
